### PR TITLE
Document pkg-config dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ You will need to install `autotools`, `autoconf` and `libusb`.  If you don't hav
   $ brew install automake
   $ brew install autoconf
   $ brew install libusb
+  $ brew install pkg-config
 ```
 
 ### Configuring


### PR DESCRIPTION
Without pkg-config, `./configure` fails with 

```
./configure: line 4601: syntax error near unexpected token `LIBUSB,'
./configure: line 4601: `PKG_CHECK_MODULES(LIBUSB, libusb-1.0 >= 1.0.0)'
```

After installing pkg-config and rerunning all install steps, it built and ran successfully.
